### PR TITLE
Fix Bitmap API from gloss-1.13

### DIFF
--- a/Graphics/Gloss/Game.hs
+++ b/Graphics/Gloss/Game.hs
@@ -97,7 +97,8 @@ boundingBox (G.ThickCircle t r)        = ((0, 0), (2 * r + t, 2 * r + t))
 boundingBox (G.Arc _ _ _)              = error "Graphics.Gloss.Game.boundingbox: Arc not implemented yet"
 boundingBox (G.ThickArc _ _ _ _)       = error "Graphics.Gloss.Game.boundingbox: ThickArc not implemented yet"
 boundingBox (G.Text _)                 = error "Graphics.Gloss.Game.boundingbox: Text not implemented yet"
-boundingBox (G.Bitmap w h _ _)         = ((0, 0), (fromIntegral w, fromIntegral h))
+boundingBox (G.Bitmap bitmap_data)     = let (w, h) = G.bitmapSize bitmap_data in ((0, 0), (fromIntegral w, fromIntegral h))
+boundingBox (G.BitmapSection rect _)   = let (w, h) = G.rectSize rect in ((0, 0), (fromIntegral w, fromIntegral h))
 boundingBox (G.Color _ p)              = boundingBox p
 boundingBox (G.Translate dx dy p)      = let ((x, y), size) = boundingBox p in ((x + dx, y + dy), size)
 boundingBox (G.Rotate _ang _p)         = error "Graphics.Gloss.Game.boundingbox: Rotate not implemented yet"

--- a/gloss-game.cabal
+++ b/gloss-game.cabal
@@ -35,7 +35,7 @@ Extra-source-files:     examples/slime/Main.hs
   
 Library
   Build-depends:        base                    >= 4 && < 5,
-                        gloss                   >= 1.8,
+                        gloss                   >= 1.13,
                         gloss-juicy             >= 0.1.2
 
   Exposed-modules:      Graphics.Gloss.Game


### PR DESCRIPTION
Hello there,

I'm not sure if you intend on maintaining this library, but since gloss got updated to 1.13 the gloss-game fails to build. This happens because the types for the Bitmap got changed a bit and therefore the `boundingBox` function on Graphics.Gloss.Game wont mach the new pattern.

I have here a patch to fix the pattern match, get the proper width and height for the bitmap and update the dependency on the .cabal file.

Another possible solution would be restrict gloss version to lower than the 1.13.

Signed-off-by: Jonathas-Conceicao <jadoliveira@inf.ufpel.edu.br>